### PR TITLE
Smoother process to set API tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,6 +225,12 @@
         "title": "Export Single Lab or Assistant",
         "category": "Artificial",
         "icon": "$(cloud-download)"
+      },
+      {
+        "command": "extension.promptForAPIToken",
+        "title": "Enter API Token for Active Context",
+        "category": "Artificial",
+        "icon": "$(notebook-mimetype)"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/artificialinc/workflow-author-extension"
   },
-  "version": "3.1.4",
+  "version": "3.1.5",
   "icon": "resources/icon.png",
   "engines": {
     "vscode": "^1.71.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,10 @@ async function setupConfig(context: vscode.ExtensionContext) {
   watchConfig.onDidChange((uri) => {
     initConfig(rootPath);
   });
-  context.subscriptions.push(watchConfig);
+  context.subscriptions.push(
+    watchConfig,
+    vscode.commands.registerCommand('extension.promptForAPIToken', configVals.promptForToken)
+  );
   return { configVals, rootPath };
 }
 

--- a/src/providers/apolloProvider.ts
+++ b/src/providers/apolloProvider.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Artificial, Inc. 
+Copyright 2022 Artificial, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 
 import { ApolloClient, HttpLink, from, gql } from '@apollo/client/core';

--- a/src/providers/apolloProvider.ts
+++ b/src/providers/apolloProvider.ts
@@ -153,6 +153,9 @@ export class ArtificialApollo {
 
   private throwError = debounce((error: any) => {
     this.outputLog.log(`Problem connecting to Artificial, check token/config ${error} ${error.networkError.result}`);
+    if (error.networkError.statusCode === 403) {
+      ConfigValues.getInstance().promptForToken();
+    }
     vscode.window.showErrorMessage(
       `Problem connecting to Artificial, check token/config ${error} ${error.networkError.result}`
     );

--- a/src/providers/apolloProvider.ts
+++ b/src/providers/apolloProvider.ts
@@ -88,6 +88,7 @@ export class ArtificialApollo {
   private static instance: ArtificialApollo;
   public apollo: ApolloClient<NormalizedCacheObject>;
   private outputLog;
+  private lastPrompt = 0;
   constructor() {
     this.outputLog = OutputLog.getInstance();
     this.apollo = this.createApollo();
@@ -153,7 +154,8 @@ export class ArtificialApollo {
 
   private throwError = debounce((error: any) => {
     this.outputLog.log(`Problem connecting to Artificial, check token/config ${error} ${error.networkError.result}`);
-    if (error.networkError.statusCode === 403) {
+    if (error.networkError.statusCode === 403 && Date.now() - this.lastPrompt > 30 * 1000) {
+      this.lastPrompt = Date.now();
       ConfigValues.getInstance().promptForToken();
     }
     vscode.window.showErrorMessage(

--- a/src/providers/configProvider.ts
+++ b/src/providers/configProvider.ts
@@ -68,7 +68,13 @@ export class ConfigValues {
       return;
     }
 
-    const config: any = YAML.parse(fs.readFileSync(configPath, 'utf-8'));
+    let config = null;
+    try {
+      config = YAML.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (err) {
+      vscode.window.showErrorMessage(`Error parsing active config`);
+    }
+
     if (!config) {
       this.hostName = '';
       this.apiToken = '';

--- a/src/providers/configProvider.ts
+++ b/src/providers/configProvider.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 */
 
 import * as vscode from 'vscode';
-import * as parse from 'yaml';
+import YAML from 'yaml';
 import * as path from 'path';
 import { pathExists } from '../utils';
 import * as fs from 'fs';
@@ -65,7 +65,7 @@ export class ConfigValues {
       return;
     }
 
-    const config: any = parse.parse(fs.readFileSync(configPath, 'utf-8'));
+    const config: any = YAML.parse(fs.readFileSync(configPath, 'utf-8'));
     if (!config) {
       this.hostName = '';
       this.apiToken = '';

--- a/src/providers/configProvider.ts
+++ b/src/providers/configProvider.ts
@@ -25,7 +25,7 @@ import { OutputLog } from './outputLogProvider';
 
 export class ConfigValues {
   private static instance: ConfigValues;
-    private outputLog;
+  private outputLog;
 
   private constructor(
     private hostName: string = '',
@@ -158,13 +158,17 @@ export class ConfigValues {
     }
 
     if (!repository.state.remotes) {
-      vscode.window.showErrorMessage('Artificial Workflow requires a git repository with remotes. Error loading repository data');
+      vscode.window.showErrorMessage(
+        'Artificial Workflow requires a git repository with remotes. Error loading repository data'
+      );
     }
 
     // Make sure remote origin is set
     const origin = repository.state.remotes.find((remote) => remote.name === 'origin');
     if (!origin) {
-      this.outputLog.log(`No remote named origin found. Remotes: ${repository.state.remotes.map((remote) => remote.name).join(', ')}`);
+      this.outputLog.log(
+        `No remote named origin found. Remotes: ${repository.state.remotes.map((remote) => remote.name).join(', ')}`
+      );
       vscode.window.showErrorMessage('Artificial Workflow requires a remote origin');
       return;
     }

--- a/src/providers/configProvider.ts
+++ b/src/providers/configProvider.ts
@@ -38,6 +38,7 @@ export class ConfigValues {
     private gitRemote: string = '',
     private githubUser: string = '',
     private githubToken: string = '',
+    private artificialConfigRoot: string = ''
   ) {
     this.outputLog = OutputLog.getInstance();
     this.initialize();
@@ -193,6 +194,11 @@ export class ConfigValues {
       return;
     }
     this.githubToken = env.PYPI_PASSWORD;
+
+    if (!env.ARTIFICIAL_CONFIG_ROOT) {
+      vscode.window.showErrorMessage('ARTIFICIAL_CONFIG_ROOT not set');
+      return;
+    }
+    this.artificialConfigRoot = env.ARTIFICIAL_CONFIG_ROOT;
   }
 }
-

--- a/src/providers/configProvider.ts
+++ b/src/providers/configProvider.ts
@@ -271,7 +271,7 @@ export class ConfigValues {
       return;
     }
 
-    const env = envParse(fs.readFileSync(envPath, 'utf-8'));
+    const env = defaultsDeep(envParse(fs.readFileSync(envPath, 'utf-8')), process.env);
     if (!env.PYPI_USER) {
       vscode.window.showErrorMessage('PYPI_USER not found in .env file');
       return;

--- a/src/providers/configProvider.ts
+++ b/src/providers/configProvider.ts
@@ -137,9 +137,9 @@ export class ConfigValues {
       return this.openTokenPrompt;
     }
 
-    if (!pathIsDirectory(path.join(this.artificialConfigRoot, this.getActiveContext()))) {
+    if (!this.isActiveContextValid()) {
       vscode.window.showErrorMessage(
-        'Invalid active context. Please edit context.yaml to point to a valid config directory.'
+        'Invalid active context. Please set contexts/context.yaml to point to a valid config folder.'
       );
       return;
     }
@@ -174,9 +174,19 @@ export class ConfigValues {
       const allContexts = this.listConfigContexts();
       if (allContexts.length === 1) {
         return allContexts[0];
-      } else {
-        throw error;
       }
+      throw error;
+    }
+  }
+
+  private isActiveContextValid(): boolean {
+    try {
+      const activeContextPath = path.join(this.artificialConfigRoot, this.getActiveContext());
+      this.outputLog.log(activeContextPath);
+      return pathIsDirectory(activeContextPath);
+    } catch (err: any) {
+      this.outputLog.log(err.toString());
+      return false;
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Artificial, Inc. 
+Copyright 2022 Artificial, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 
 import * as fs from 'fs';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,14 @@ export function pathExists(p: string): boolean {
   return true;
 }
 
+export function pathIsDirectory(p: string): boolean {
+  return pathExists(p) && fs.lstatSync(p).isDirectory();
+}
+
+export function pathIsFile(p: string): boolean {
+  return pathExists(p) && fs.lstatSync(p).isFile();
+}
+
 export async function initConfig(rootPath: string) {
   if (!pathExists(rootPath + '/tmp')) {
     await artificialAwaitTask('tmp Directory Creation', 'mkdir tmp');


### PR DESCRIPTION
This PR adds a streamlined way to interact with API tokens. When a call to the instance returns a 403, or the user runs a specific command in the extension, prompt the user for an API token. If the user enters the api token, put the api token into secrets.yaml with the correct format (merging it in if secrets.yaml already exists).

https://github.com/artificialinc/workflow-author-extension/assets/142252044/1dac6f64-a024-46ea-ae5d-5bccba9f9a59

